### PR TITLE
fix: resolve broken 'meltano install' process in Dockerfile

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -12,9 +12,6 @@ RUN pip install -r requirements.txt
 COPY . .
 RUN meltano install
 
-# Pin `discovery.yml` manifest by copying cached version to project root
-RUN cp -n .meltano/cache/discovery.yml . 2>/dev/null || :
-
 # Don't allow changes to containerized project files
 ENV MELTANO_PROJECT_READONLY 1
 

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /project
 COPY ./requirements.txt .
 RUN pip install -r requirements.txt
 
-# Install all plugins into the `.meltano` directory
-COPY ./meltano.yml .
+# Copy over Meltano project directory
+COPY . .
 RUN meltano install
 
 # Pin `discovery.yml` manifest by copying cached version to project root
@@ -17,9 +17,6 @@ RUN cp -n .meltano/cache/discovery.yml . 2>/dev/null || :
 
 # Don't allow changes to containerized project files
 ENV MELTANO_PROJECT_READONLY 1
-
-# Copy over remaining project files
-COPY . .
 
 # Expose default port used by `meltano ui`
 EXPOSE 5000


### PR DESCRIPTION
Resolves an issue where `meltano install` would not have access to lock files and would not have access to files referenced in `include_paths`.

The original approach was built when cache busting could be avoided by only copying in `meltano.yml`, then running `meltano install`, and then copying in the rest. This process broke when we added `include_paths` feature and then broke further when we designed the lock file system.

Resolves https://github.com/meltano/meltano/issues/6701