### PR TITLE
Update Dockerfile to not use LegacyKeyValueFormat

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN meltano install
 
 # Don't allow changes to containerized project files
-ENV MELTANO_PROJECT_READONLY 1
+ENV MELTANO_PROJECT_READONLY=1
 
 # Expose default port used by `meltano ui`
 EXPOSE 5000


### PR DESCRIPTION
Building the dockerfile previously would give

```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 16)
```

This change removes that warning.